### PR TITLE
Handle the case where output.xml has non printable characters.

### DIFF
--- a/popt/popt.py
+++ b/popt/popt.py
@@ -160,7 +160,7 @@ def read_arguments():
     p.add_argument('--version', '-v', action='version', help='Print version', version=get_version())
     args = p.parse_args()
 
-    print(in_plain_text(args.filename, skip_timestamps=args.skip_timestamps, width=args.width))
+    print(in_plain_text(args.filename, skip_timestamps=args.skip_timestamps, width=args.width)).encode('utf-8'))
 
 
 if __name__ == '__main__':

--- a/popt/popt.py
+++ b/popt/popt.py
@@ -160,7 +160,7 @@ def read_arguments():
     p.add_argument('--version', '-v', action='version', help='Print version', version=get_version())
     args = p.parse_args()
 
-    print(in_plain_text(args.filename, skip_timestamps=args.skip_timestamps, width=args.width)).encode('utf-8'))
+    print(in_plain_text(args.filename, skip_timestamps=args.skip_timestamps, width=args.width).encode('utf-8'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Encode the output as UTF-8 to address the cases where the robot output.xml has non printable characters.